### PR TITLE
Fix Missing CFG Variable in Iterate Function

### DIFF
--- a/train.py
+++ b/train.py
@@ -547,6 +547,7 @@ def main(CFG):
         mode="val",
         device=device,
         task=CFG.task,
+        CFG=CFG
     )
 
     val_loss, val_metrics, wandb_table = iterate(log=True, **arg_dict)
@@ -576,7 +577,8 @@ def main(CFG):
         mode="test",
         device=device,
         task=CFG.task,
-        log=True
+        log=True,
+        CFG=CFG
     )
     print("Test Result")
     if CFG.task == "crop_type":


### PR DESCRIPTION
This pull request addresses an issue where the `CFG` variable was not being passed to the `iterate` function after training completion. As a result, the function was receiving a `None` value for CFG, leading to errors during execution. To resolve this, the CFG variable has been added as a parameter to the `iterate` function, ensuring that the necessary configuration is available for successful execution.